### PR TITLE
fix(rpc): zero gas config for tracing methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## Dymension changes
+
+### State Machine Breaking
+- (evm) Disabled contract creation.
+
+### Bug Fixes
+- (rpc) [#6](https://github.com/dymensionxyz/ethermint/pull/6) Zero gas config for tracing methods
+
 ## Unreleased
 
 ### State Machine Breaking

--- a/app/ante/setup.go
+++ b/app/ante/setup.go
@@ -17,11 +17,11 @@ package ante
 
 import (
 	"errors"
+	"github.com/evmos/ethermint/utils"
 	"strconv"
 
 	errorsmod "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	errortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -49,9 +49,8 @@ func (esc EthSetupContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simul
 	}
 
 	// We need to setup an empty gas config so that the gas is consistent with Ethereum.
-	newCtx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter()).
-		WithKVGasConfig(storetypes.GasConfig{}).
-		WithTransientKVGasConfig(storetypes.GasConfig{})
+	newCtx = ctx.WithGasMeter(sdk.NewInfiniteGasMeter())
+	newCtx = utils.UseZeroGasConfig(newCtx)
 
 	// Reset transient gas used to prepare the execution of current cosmos tx.
 	// Transient gas-used is necessary to sum the gas-used of cosmos tx, when it contains multiple eth msgs.

--- a/utils/sdk_context.go
+++ b/utils/sdk_context.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// UseZeroGasConfig set the gas config to zero for both KV and TransientKV store.
+// Must be called before EVM execution to ignore gas consumption on Cosmos side.
+// Gas consumption should be decided by Ethereum side.
+func UseZeroGasConfig(ctx sdk.Context) sdk.Context {
+	return ctx.WithKVGasConfig(storetypes.GasConfig{}).WithTransientKVGasConfig(storetypes.GasConfig{})
+}

--- a/utils/sdk_context_test.go
+++ b/utils/sdk_context_test.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestUseZeroGasConfig(t *testing.T) {
+	ctx := sdk.Context{}.
+		WithKVGasConfig(storetypes.KVGasConfig()).
+		WithTransientKVGasConfig(storetypes.TransientGasConfig())
+
+	require.NotZero(t, ctx.KVGasConfig().ReadCostFlat) // ensure test data
+
+	newCtx := UseZeroGasConfig(ctx)
+
+	newKvGasConfig := newCtx.KVGasConfig()
+	require.Zero(t, newKvGasConfig.ReadCostFlat)
+
+	newTransientKvGasConfig := newCtx.TransientKVGasConfig()
+	require.Zero(t, newTransientKvGasConfig.ReadCostFlat)
+
+	require.NotZero(t, ctx.KVGasConfig().ReadCostFlat, "the change should not effect the original context")
+}

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/evmos/ethermint/utils"
 	"math/big"
 	"time"
 
@@ -231,6 +232,7 @@ func (k Keeper) EthCall(c context.Context, req *types.EthCallRequest) (*types.Ms
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
+	ctx = utils.UseZeroGasConfig(ctx) // avoid Cosmos consumes gas unexpectedly.
 
 	var args types.TransactionArgs
 	err := json.Unmarshal(req.Args, &args)
@@ -273,6 +275,8 @@ func (k Keeper) EstimateGas(c context.Context, req *types.EthCallRequest) (*type
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
+	ctx = utils.UseZeroGasConfig(ctx) // avoid Cosmos consumes gas unexpectedly.
+
 	chainID, err := getChainID(ctx, req.ChainId)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -410,6 +414,8 @@ func (k Keeper) TraceTx(c context.Context, req *types.QueryTraceTxRequest) (*typ
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
+	ctx = utils.UseZeroGasConfig(ctx) // avoid Cosmos consumes gas unexpectedly.
+
 	ctx = ctx.WithBlockHeight(contextHeight)
 	ctx = ctx.WithBlockTime(req.BlockTime)
 	ctx = ctx.WithHeaderHash(common.Hex2Bytes(req.BlockHash))
@@ -487,6 +493,7 @@ func (k Keeper) TraceBlock(c context.Context, req *types.QueryTraceBlockRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(c)
+	ctx = utils.UseZeroGasConfig(ctx) // avoid Cosmos consumes gas unexpectedly.
 	ctx = ctx.WithBlockHeight(contextHeight)
 	ctx = ctx.WithBlockTime(req.BlockTime)
 	ctx = ctx.WithHeaderHash(common.Hex2Bytes(req.BlockHash))
@@ -540,6 +547,8 @@ func (k *Keeper) traceTx(
 	commitMessage bool,
 	tracerJSONConfig json.RawMessage,
 ) (*interface{}, uint, error) {
+	ctx = utils.UseZeroGasConfig(ctx) // avoid Cosmos consumes gas unexpectedly.
+
 	// Assemble the structured logger or the JavaScript tracer
 	var (
 		tracer    tracers.Tracer

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -41,7 +41,7 @@ var _ types.MsgServer = &Keeper{}
 // so that it can implements and call the StateDB methods without receiving it as a function
 // parameter.
 func (k *Keeper) EthereumTx(goCtx context.Context, msg *types.MsgEthereumTx) (*types.MsgEthereumTxResponse, error) {
-	ctx := sdk.UnwrapSDKContext(goCtx)
+	ctx := sdk.UnwrapSDKContext(goCtx) // this context already has zero gas config, set by AnteHandler
 
 	sender := msg.From
 	tx := msg.AsTransaction()


### PR DESCRIPTION
Problem: gas config was not set correctly on tracing methods, leading to some issues with `eth_trace*` endpoints.