### PR TITLE
imp(test): add more IT test securing negative amount transfer

### DIFF
--- a/rpc/namespaces/ethereum/eth/eth_rpc_it_suite/eth_api_account_vfc_test.go
+++ b/rpc/namespaces/ethereum/eth/eth_rpc_it_suite/eth_api_account_vfc_test.go
@@ -82,9 +82,11 @@ func (suite *EthRpcTestSuite) Test_GetCode_VFC() {
 			acc2 := suite.App().AccountKeeper().GetAccount(suite.Ctx(), vfbcContractAddressOfNative.Bytes())
 			_, isBaseAccount := acc2.(*authtypes.BaseAccount)
 			suite.Require().True(isBaseAccount, "account must be overridden to a BaseAccount")
+
+			suite.Commit()
 		}
 
-		code, err = ethPublicApi.GetCode(vfbcContractAddressOfNative, latestBlock)
+		code, err = suite.GetEthPublicAPI().GetCode(vfbcContractAddressOfNative, latestBlock)
 		suite.Require().NoError(err, "failed to get code")
 		suite.Equal(
 			hexutil.Bytes(types.VFBCCode),

--- a/x/evm/it_suite_test/evm_it_suite_test.go
+++ b/x/evm/it_suite_test/evm_it_suite_test.go
@@ -1,0 +1,64 @@
+package vfc_it_suite_test
+
+//goland:noinspection SpellCheckingInspection
+import (
+	"encoding/json"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/evmos/ethermint/integration_test_util"
+	itutiltypes "github.com/evmos/ethermint/integration_test_util/types"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+//goland:noinspection GoSnakeCaseUsage,SpellCheckingInspection
+type EvmITSuite struct {
+	suite.Suite
+	CITS *integration_test_util.ChainIntegrationTestSuite
+}
+
+func (suite *EvmITSuite) App() itutiltypes.ChainApp {
+	return suite.CITS.ChainApp
+}
+
+func (suite *EvmITSuite) Ctx() sdk.Context {
+	return suite.CITS.CurrentContext
+}
+
+func (suite *EvmITSuite) Commit() {
+	suite.CITS.Commit()
+}
+
+func TestVfcITSuite(t *testing.T) {
+	suite.Run(t, new(EvmITSuite))
+}
+
+func (suite *EvmITSuite) SetupSuite() {
+}
+
+func (suite *EvmITSuite) SetupTest() {
+	suite.CITS = integration_test_util.CreateChainIntegrationTestSuite(suite.T(), suite.Require())
+}
+
+func (suite *EvmITSuite) TearDownTest() {
+	suite.CITS.Cleanup()
+}
+
+func (suite *EvmITSuite) TearDownSuite() {
+}
+
+func (suite *EvmITSuite) GetTxReceipt(txHash common.Hash) *ethtypes.Receipt {
+	mapReceipt, err := suite.CITS.RpcBackend.GetTransactionReceipt(txHash)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(mapReceipt)
+
+	bzMapReceipt, err := json.Marshal(mapReceipt)
+	suite.Require().NoError(err)
+
+	var receipt ethtypes.Receipt
+	err = json.Unmarshal(bzMapReceipt, &receipt)
+	suite.Require().NoError(err)
+
+	return &receipt
+}

--- a/x/evm/it_suite_test/tx_test.go
+++ b/x/evm/it_suite_test/tx_test.go
@@ -1,0 +1,145 @@
+package vfc_it_suite_test
+
+import (
+	"encoding/json"
+	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	evmtypes "github.com/evmos/ethermint/x/evm/types"
+	"math/big"
+)
+
+func (suite *EvmITSuite) TestTransfer() {
+	sender := suite.CITS.WalletAccounts.Number(1)
+	receiver := suite.CITS.WalletAccounts.Number(2)
+
+	suite.CITS.MintCoin(sender, suite.CITS.NewBaseCoin(30))
+
+	balance := func(address common.Address) *big.Int {
+		return suite.App().EvmKeeper().GetBalance(suite.Ctx(), address)
+	}
+
+	tests := []struct {
+		name        string
+		amount      *big.Int
+		wantSuccess bool
+	}{
+		{
+			name:        "send small amount",
+			amount:      big.NewInt(10),
+			wantSuccess: true,
+		},
+		{
+			name:        "send all",
+			amount:      balance(sender.GetEthAddress()),
+			wantSuccess: false,
+		},
+		{
+			name:        "send more than have",
+			amount:      new(big.Int).Add(common.Big1, balance(sender.GetEthAddress())),
+			wantSuccess: false,
+		},
+		{
+			name:        "send zero",
+			amount:      common.Big0,
+			wantSuccess: true,
+		},
+		{
+			name:        "send negative",
+			amount:      big.NewInt(-1),
+			wantSuccess: false,
+		},
+	}
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			ctx := suite.Ctx()
+
+			from := sender.GetEthAddress()
+			to := receiver.GetEthAddress()
+
+			senderBalanceBefore := balance(from)
+			receiverBalanceBefore := balance(to)
+
+			baseFee := suite.CITS.ChainApp.FeeMarketKeeper().GetBaseFee(suite.Ctx())
+
+			msgEthereumTx := evmtypes.NewTx(
+				suite.CITS.ChainApp.EvmKeeper().ChainID(),
+				suite.CITS.ChainApp.EvmKeeper().GetNonce(ctx, from),
+				&to,
+				tt.amount,    // amount
+				params.TxGas, // gas limit
+				nil,          // gas price
+				baseFee,      // gas fee cap
+				baseFee,      // gas tip cap
+				nil,          // data
+				&ethtypes.AccessList{},
+			)
+			msgEthereumTx.From = from.String()
+
+			resp, err := suite.CITS.DeliverEthTx(sender, msgEthereumTx)
+
+			suite.Commit()
+
+			senderBalanceAfter := balance(from)
+			receiverBalanceAfter := balance(to)
+
+			if tt.wantSuccess {
+				suite.Require().NoError(err)
+				suite.Require().NotNil(resp)
+
+				receipt := suite.GetTxReceipt(common.HexToHash(resp.EthTxHash))
+				suite.Require().NotNil(receipt)
+
+				suite.Equal(ethtypes.ReceiptStatusSuccessful, receipt.Status, "tx must be successful")
+				suite.Empty(resp.EvmError)
+
+				amount := tt.amount
+				if amount == nil {
+					amount = common.Big0
+				}
+
+				effectivePrice := msgEthereumTx.GetEffectiveFee(baseFee)
+				txFee := effectivePrice
+
+				suite.Equalf(
+					new(big.Int).Sub(
+						senderBalanceBefore,
+						new(big.Int).Add(
+							amount,
+							txFee,
+						),
+					),
+					senderBalanceAfter,
+					"sender balance must decrease by (%s + %s) from %s", amount, txFee, senderBalanceBefore,
+				)
+				suite.Equalf(
+					new(big.Int).Add(
+						receiverBalanceBefore,
+						amount,
+					),
+					receiverBalanceAfter,
+					"receiver balance must increase by %s from %s", amount, receiverBalanceBefore,
+				)
+			} else {
+				suite.Require().Error(err)
+
+				mapReceipt, err := suite.CITS.RpcBackend.GetTransactionReceipt(common.HexToHash(resp.EthTxHash))
+				suite.Require().NoError(err)
+
+				if mapReceipt != nil {
+					bzMapReceipt, err := json.Marshal(mapReceipt)
+					suite.Require().NoError(err)
+
+					var receipt ethtypes.Receipt
+					err = json.Unmarshal(bzMapReceipt, &receipt)
+					suite.Require().NoError(err)
+
+					suite.Equal(ethtypes.ReceiptStatusFailed, receipt.Status, "tx must be failed")
+
+					suite.Equal(senderBalanceBefore, senderBalanceAfter, "sender balance must not change")
+					suite.Equal(receiverBalanceBefore, receiverBalanceAfter, "receiver balance must not change")
+				}
+			}
+		})
+	}
+}

--- a/x/evm/keeper/state_transition_vfc_bank.go
+++ b/x/evm/keeper/state_transition_vfc_bank.go
@@ -240,7 +240,9 @@ func (k *Keeper) evmCallVirtualFrontierBankContract(
 		}
 
 		senderBalance := k.bankKeeper.GetBalance(ctx, sender.Bytes(), bankContractMetadata.MinDenom)
+
 		sendAmount := sdk.NewCoin(bankContractMetadata.MinDenom, sdk.NewIntFromBigInt(amount))
+		// the above also checks if the amount is negative and if it has more than 256 bits
 
 		if senderBalance.Amount.LT(sendAmount.Amount) {
 			return types.NewExecVFCRevert(opGasCostOnRevert, errors.New("ERC20: transfer amount exceeds balance"))

--- a/x/evm/keeper/vfc_it_suite_test/vfbc_exec_test.go
+++ b/x/evm/keeper/vfc_it_suite_test/vfbc_exec_test.go
@@ -187,6 +187,19 @@ func (suite *VfcITSuite) TestExecVirtualFrontierBankContract() {
 			wantErrContains: "",
 		},
 		{
+			name: "fail - VFBC transfer(address,uint256) - negative amount",
+			inputFunc: func() []byte {
+				suite.CITS.MintCoin(receiver, suite.CITS.NewBaseCoin(1)) // mint some coin to receiver so will not be negative when increased by a negative number
+
+				inputCallData, err := integration_test_util.ERC20MinterBurnerDecimalsContract.ABI.Pack("transfer", receiver.GetEthAddress(), big.NewInt(-1))
+				suite.Require().NoError(err)
+				return inputCallData
+			},
+			targetContract:  vfbcContract,
+			wantSuccess:     false,
+			wantErrContains: "execution reverted",
+		},
+		{
 			name: "pass - ERC-20 approve(address,uint256)",
 			inputFunc: func() []byte {
 				// lazySender approve tokenOwner to spend max 100 tokens on behalf of lazySender

--- a/x/evm/keeper/vfc_it_suite_test/vfbc_exec_test.go
+++ b/x/evm/keeper/vfc_it_suite_test/vfbc_exec_test.go
@@ -200,6 +200,27 @@ func (suite *VfcITSuite) TestExecVirtualFrontierBankContract() {
 			wantErrContains: "execution reverted",
 		},
 		{
+			name: "safe - VFBC transfer(address,uint256) - amount overflow 256 bits",
+			// this case won't happen because there are only 256 bits for the amount
+			inputFunc: func() []byte {
+				overflow := make([]byte, 33)
+				overflow[0] = 0xFF
+				overflowAmount := new(big.Int).SetBytes(overflow)
+
+				inputCallData, err := integration_test_util.ERC20MinterBurnerDecimalsContract.ABI.Pack("transfer", receiver.GetEthAddress(), overflowAmount)
+				suite.Require().NoError(err)
+
+				// take the last 32 bytes
+				last32Bytes := inputCallData[len(inputCallData)-32:]
+				suite.Require().Equal(overflow[1:], last32Bytes)
+
+				return inputCallData
+			},
+			targetContract:  vfbcContract,
+			wantSuccess:     true,
+			wantErrContains: "",
+		},
+		{
 			name: "pass - ERC-20 approve(address,uint256)",
 			inputFunc: func() []byte {
 				// lazySender approve tokenOwner to spend max 100 tokens on behalf of lazySender


### PR DESCRIPTION
This PR:
- Added some tests to ensure can not do negative amount transfer txs via EVM module.
- Same for the VFBC
- Add explicitly check (duplicated) on VFBC `transfer(address,uint256)` just for safety purpose + comment to explanation