### PR TITLE
imp(evm): restrict VFBC deployment on top of Module Account or EOA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (evm) [#11](https://github.com/dymensionxyz/ethermint/pull/11) Disabled contract creation for Dymension chains only (adjust the absolute logic in [#3](https://github.com/dymensionxyz/ethermint/pull/3))
 - (evm) [#11](https://github.com/dymensionxyz/ethermint/pull/11) Virtual Frontier Contract
 - (evm) [#15](https://github.com/dymensionxyz/ethermint/pull/15) VFBC deployment no longer revert changes on error while contract deployment
+- (evm) [#16](https://github.com/dymensionxyz/ethermint/pull/16) Restrict VFBC deployment on top of Module Account or EOA
 
 ### Bug Fixes
 - (rpc) [#6](https://github.com/dymensionxyz/ethermint/pull/6) Zero gas config for tracing methods


### PR DESCRIPTION
Current behavior is deploy VFBC no matter account is existing or not, no matter the type of the account is. The only restriction is the existing account must Not be a contract account.
Even tho the chance of override an existing Module Account or EOA is almost equals to brute forcing private key of a wallet.
This PR can be ignored without any consequence.

Brief of code change:
- Restrict deploy VFBC if existing account is a Module Account.
- Restrict deploy VFBC if existing account has sequence number > 0 (sign of EOA, as user used private key to sent at least one transaction).

Plus the existing one (restrict deploy VFBC if existing account is a VFBC contract), we have 3.

Added test-cases:
- Proof of VFBC still able to be deployed if there is an existing account at the predicted address.
- Test cases for the new restriction as defined above.

In case VFBC was stopped deploying due to the restriction defined above. We just need to shift sequence number of the deployment module account by one and everything will be fine.