### PR TITLE
Fix typo Update tx.proto

### DIFF
--- a/proto/ethermint/evm/v1/tx.proto
+++ b/proto/ethermint/evm/v1/tx.proto
@@ -101,7 +101,7 @@ message AccessListTx {
   bytes s = 11;
 }
 
-// DynamicFeeTx is the data of EIP-1559 dinamic fee transactions.
+// DynamicFeeTx is the data of EIP-1559 dynamic fee transactions.
 message DynamicFeeTx {
   option (gogoproto.goproto_getters) = false;
   option (cosmos_proto.implements_interface) = "TxData";


### PR DESCRIPTION
Details of the Fix:
Original text: "dinamic fee transactions"
Corrected text: "dynamic fee transactions"
Explanation:
The word "dinamic" was misspelled and corrected to "dynamic."
This fix ensures accurate terminology in the protocol buffer definition, which is crucial for maintaining clear and professional documentation for developers working with this file.
Change Summary:
File affected: proto/ethermint/evm/v1/tx.proto
Lines affected: Line 101
Number of changes: One deletion (incorrect text) and one addition (corrected text).